### PR TITLE
mcp-toolkit, beta-mcp-skills: update docs for current docker mcp CLI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "mcp-toolkit",
       "source": "./plugins/mcp-toolkit",
       "description": "Integrates Docker Desktop's MCP Toolkit with Claude Code, enabling access to containerized MCP servers. Requires Docker Desktop 4.28+ with MCP Toolkit enabled.",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "author": {
         "name": "Docker Inc."
       },
@@ -25,7 +25,7 @@
       "name": "beta-mcp-skills",
       "source": "./plugins/beta-mcp-skills",
       "description": "Beta MCP skills from Docker",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "Docker Inc."
       },

--- a/plugins/beta-mcp-skills/.claude-plugin/plugin.json
+++ b/plugins/beta-mcp-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "beta-mcp-skills",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Beta MCP skills from Docker",
   "author": {
     "name": "Docker Inc.",

--- a/plugins/beta-mcp-skills/skills/mcp-server-yaml-creator/SKILL.md
+++ b/plugins/beta-mcp-skills/skills/mcp-server-yaml-creator/SKILL.md
@@ -150,7 +150,7 @@ After creating server.yaml, add it to a profile or catalog:
 docker mcp profile server add <profile-id> --server file://./server.yaml
 
 # Create catalog with the server
-docker mcp catalog-next create <catalog-id> --title "My Catalog" --server file://./server.yaml
+docker mcp catalog create <oci-reference> --title "My Catalog" --server file://./server.yaml
 ```
 
 Be sure to ask the user what they would like to do. The recommended approach would be to create a new catalog and add it to a new catalog.

--- a/plugins/mcp-toolkit/.claude-plugin/plugin.json
+++ b/plugins/mcp-toolkit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-toolkit",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Integrates Docker Desktop's MCP Toolkit with Claude Code, enabling access to containerized MCP servers. Designed specifically for Docker Desktop's bundled MCP Gateway. Requires Docker Desktop 4.28+ with MCP Toolkit feature enabled.",
   "author": {
     "name": "Docker Inc.",

--- a/plugins/mcp-toolkit/README.md
+++ b/plugins/mcp-toolkit/README.md
@@ -37,7 +37,7 @@ If this command fails, ensure:
 When enabled, this plugin:
 
 1. Automatically starts the Docker MCP Gateway as an MCP server within Claude Code
-2. Exposes all MCP servers configured in Docker Desktop (via `docker mcp server enable`)
+2. Exposes all MCP servers configured in Docker Desktop (via the MCP Toolkit UI or `docker mcp profile server add`)
 3. Makes containerized MCP tools, resources, and prompts available to Claude
 
 ## Available Commands
@@ -61,21 +61,23 @@ This plugin provides helpful slash commands for managing and debugging Docker MC
 
 ### Configuration
 
-This plugin uses the default Docker MCP Gateway configuration. To configure which MCP servers are available:
+This plugin uses the default Docker MCP Gateway configuration. The recommended workflow is to manage MCP servers via Docker Desktop's MCP Toolkit UI (Settings → MCP Toolkit). Equivalent CLI commands:
 
 ```bash
 # List available servers in the Docker MCP catalog
-docker mcp catalog show docker-mcp
+docker mcp catalog show mcp/docker-mcp-catalog
 
-# Enable specific MCP servers
-docker mcp server enable <server-name>
+# Add servers to a profile (creates one if needed)
+docker mcp profile server add <profile-id> --server <server-ref>
 
-# List currently enabled servers
-docker mcp server ls
+# List configured servers across profiles
+docker mcp profile server ls
 
 # Configure server settings (if needed)
-docker mcp config write '<yaml-config>'
+docker mcp profile config <profile-id> --set <server>.<key>=<value>
 ```
+
+See [MCP Profiles](https://docs.docker.com/ai/mcp-catalog-and-toolkit/profiles/) for the profile concept and UI workflow, and [Use MCP Toolkit from the CLI](https://docs.docker.com/ai/mcp-catalog-and-toolkit/cli/) for the accepted `<server-ref>` URIs (`catalog://`, `docker://`, `https://`, `file://`) and full command reference.
 
 ### Verification
 
@@ -98,7 +100,7 @@ Once the plugin is installed and Claude Code is running, the Docker MCP Gateway 
 
 **Error**: Gateway starts but no tools are available
 
-**Solution**: Enable MCP servers using `docker mcp server enable <server-name>`
+**Solution**: Enable MCP servers via Docker Desktop's MCP Toolkit UI, or with `docker mcp profile server add <profile-id> --server <server-ref>`
 
 ### Gateway connection issues
 
@@ -106,7 +108,7 @@ Once the plugin is installed and Claude Code is running, the Docker MCP Gateway 
 
 **Solution**:
 1. Verify Docker daemon is running: `docker ps`
-2. Check MCP server status: `docker mcp server ls`
+2. Check MCP server status: `docker mcp profile server ls`
 3. Review gateway logs for errors
 
 ## Learn More

--- a/plugins/mcp-toolkit/commands/gateway-status.md
+++ b/plugins/mcp-toolkit/commands/gateway-status.md
@@ -9,7 +9,7 @@ Display the current status of Docker MCP Gateway and configured MCP servers.
 
 ## Current Status
 
-- **Enabled MCP Servers**: !`docker mcp server ls`
+- **Enabled MCP Servers**: !`docker mcp profile server ls`
 
 ## Summary
 


### PR DESCRIPTION
## Summary

The `docker mcp` CLI has been reorganized.

The command `/mcp-toolkit:gateway-status` previously failed on every invocation with `This command is obsolete. See docker mcp profile server ls --help instead.` This PR fixes that and the related documentation rot.

Verified against `docker mcp v0.40.3` and against `docs.docker.com/ai/mcp-catalog-and-toolkit/{profiles,cli}`.
