### PR TITLE
feat: list sbx-kits (Docker Sandboxes kit authoring skill)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -33,6 +33,23 @@
       "category": "integration",
       "license": "MIT",
       "strict": false
+    },
+    {
+      "name": "sbx-kits",
+      "source": {
+        "source": "github",
+        "repo": "docker/sbx-kits-contrib",
+        "ref": "main"
+      },
+      "description": "Author Docker Sandboxes kits (spec.yaml v2) — schema, lifecycle, composition, distribution, and TCK testing.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Docker Inc."
+      },
+      "keywords": ["docker", "sandboxes", "sbx", "kits", "spec.yaml"],
+      "category": "integration",
+      "license": "Apache-2.0",
+      "strict": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a `sbx-kits` entry to `plugins[]` referencing `docker/sbx-kits-contrib` **by git source** (`{"source": "github", "repo": "docker/sbx-kits-contrib", "ref": "main"}`) rather than vendoring the skill's files into this repo. This is the first external-source entry in this marketplace — existing entries all use the `./plugins/...` local-path convention, but that's a convention, not a schema requirement.
- The skill is `sbx-kits-contrib`'s `kit-author` skill: reference documentation for authoring Docker Sandboxes kits (`spec.yaml`, v2 schema).
- **Entry is named `sbx-kits`, matching that repo's own `.claude-plugin/plugin.json` name** (docker/sbx-kits-contrib#126). Component namespacing (`<plugin-name>:<skill-name>`) is driven by `plugin.json`'s own name, while the marketplace entry's name is only the install alias; a mismatch would mean `/plugin install X@docker` produces something invoked as `Y:skill-name`, which is confusing. `sbx-kits` is a deliberate, user-facing namespace choice, not tied to the source repo's name — chosen so that if more skills fold in later (e.g. workflow skills currently living in `sbx-toolkit`), they all land under this one `sbx-kits:` prefix. Namespacing has no cross-repo merging mechanism, so any future skills sharing this prefix must live in the same `sbx-kits-contrib` repo/plugin, not a separately-sourced one.

## Depends on
- docker/sbx-kits-contrib#126 — adds `.claude-plugin/plugin.json` and trims/fixes the skill's activation trigger, which is what makes that repo a valid, discoverable plugin target. **This PR's `ref: main` will not resolve to a usable plugin until #126 merges.** Opening as draft for that reason; will mark ready once #126 is in and, ideally, once a release tag exists to pin `ref` to instead of the mutable `main` branch.
- docker/sbx-kits-contrib#125 — unrelated doc fix, no dependency, listed for context.

## Test plan
- [x] `marketplace.json` is valid JSON.
- [ ] After #126 merges: `/plugin marketplace add docker/claude-plugins` → `/plugin install sbx-kits@docker` successfully discovers `skills/kit-author/` from the referenced repo, invoked as `/sbx-kits:kit-author`.
- [ ] Follow-up: pin `ref` to a release tag/SHA instead of `main` once one is cut.